### PR TITLE
Move Leaderboard above menu buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,13 @@
             </p>
           </header>
 
+          <section class="leaderboard">
+            <h2>Top Scores</h2>
+            <div id="leaderboard-list" class="leaderboard-list">
+              <p class="empty-message">No scores yet. Be the first to play!</p>
+            </div>
+          </section>
+
           <nav class="menu-nav">
             <button id="btn-start-game" class="menu-button primary">
               Start New Game
@@ -42,13 +49,6 @@
                 <kbd>:q</kbd>
                 <span>Quit to menu</span>
               </div>
-            </div>
-          </section>
-
-          <section class="leaderboard">
-            <h2>Top Scores</h2>
-            <div id="leaderboard-list" class="leaderboard-list">
-              <p class="empty-message">No scores yet. Be the first to play!</p>
             </div>
           </section>
         </div>


### PR DESCRIPTION
Resolves #15

- Reordered Main Menu sections to show Leaderboard before navigation buttons
- New order: Header -> Leaderboard -> Navigation buttons -> Instructions
- All tests passing (448 tests)